### PR TITLE
Revert "Bump tzinfo from 1.2.9 to 1.2.10"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thread_safe (0.3.6)
-    tzinfo (1.2.10)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     tzinfo-data (1.2021.1)
       tzinfo (>= 1.0.0)


### PR DESCRIPTION
Reverts ZHaskell/docs#19